### PR TITLE
channelmgnt: update cvt and testwiki acls

### DIFF
--- a/modules/sopel/files/channelmgnt.json
+++ b/modules/sopel/files/channelmgnt.json
@@ -31,7 +31,9 @@
       "chanops":[
          "Voidwalker",
          "Reception123",
-         "raidarr"
+         "raidarr",
+         "Agent",
+         "JohnLewis"
       ]
    },
    "##RhinosF1":{
@@ -99,7 +101,6 @@
          "NDKilla",
          "Voidwalker",
          "Zppix",
-         "RhinosF1",
          "dmehus"
       ]
    },
@@ -209,7 +210,6 @@
          "NDKilla",
          "Voidwalker",
          "Zppix",
-         "RhinosF1",
          "MacFan4000"
       ]
    },


### PR DESCRIPTION
remove RhinosF1’s explicit op in testwiki channels; add John and Agent for cvt channels