### PR TITLE
channelmgnt: remove dmehus from #miraheze-dev

### DIFF
--- a/modules/sopel/files/channelmgnt.json
+++ b/modules/sopel/files/channelmgnt.json
@@ -180,7 +180,6 @@
     "#miraheze-dev":{
       "chanops":[
          "CosmicAlpha",
-         "dmehus",
          "Naleksuh",
          "Reception123"
       ]
@@ -192,9 +191,9 @@
    },
     "#miraheze-feed-login":{
       "chanops":[
+         "CosmicAlpha",
          "MacFan4000",
          "Reception123",
-         "CosmicAlpha",
          "Voidwalker",
          "Agent"
       ]


### PR DESCRIPTION
Also alphabeticalise #miraheze-feed-login as when my IRC username was changed it wasn't reordered.